### PR TITLE
Refactor CLI for better handling of global URI arg

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -47,7 +47,7 @@ pub async fn vacuum(table: DeltaTable, options: VacuumOptions) -> Result<(), Del
     Ok(())
 }
 
-pub async fn schema(table: &DeltaTable) -> Result<(), DeltaTableError> {
+pub fn schema(table: &DeltaTable) -> Result<(), DeltaTableError> {
     match table.schema() {
         // TODO: Serialize to JSON instead of printing Rust types.
         Some(schema) => println!("schema: {schema:#?}"),

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -1,8 +1,7 @@
 use chrono::Duration;
-use deltalake::{operations::optimize::OptimizeType, DeltaOps, DeltaTableError};
+use deltalake::{operations::optimize::OptimizeType, DeltaOps, DeltaTable, DeltaTableError};
 
-pub async fn compact(uri: impl AsRef<str>) -> Result<(), DeltaTableError> {
-    let table = deltalake::open_table(uri).await?;
+pub async fn compact(table: DeltaTable) -> Result<(), DeltaTableError> {
     let ops = DeltaOps(table);
 
     // TODO: Configure optimization properties: `.with_...`
@@ -13,8 +12,7 @@ pub async fn compact(uri: impl AsRef<str>) -> Result<(), DeltaTableError> {
     Ok(())
 }
 
-pub async fn zorder(uri: impl AsRef<str>, columns: Vec<String>) -> Result<(), DeltaTableError> {
-    let table = deltalake::open_table(uri).await?;
+pub async fn zorder(table: DeltaTable, columns: Vec<String>) -> Result<(), DeltaTableError> {
     let ops = DeltaOps(table);
 
     // TODO: Configure optimization properties: `.with_...`
@@ -31,8 +29,7 @@ pub struct VacuumOptions {
     pub dry_run: bool,
 }
 
-pub async fn vacuum(uri: impl AsRef<str>, options: VacuumOptions) -> Result<(), DeltaTableError> {
-    let table = deltalake::open_table(uri).await?;
+pub async fn vacuum(table: DeltaTable, options: VacuumOptions) -> Result<(), DeltaTableError> {
     let ops = DeltaOps(table);
 
     // TODO: Allow control of commit behaviour.
@@ -50,9 +47,7 @@ pub async fn vacuum(uri: impl AsRef<str>, options: VacuumOptions) -> Result<(), 
     Ok(())
 }
 
-pub async fn schema(uri: impl AsRef<str>) -> Result<(), DeltaTableError> {
-    let table = deltalake::open_table(uri).await?;
-
+pub async fn schema(table: &DeltaTable) -> Result<(), DeltaTableError> {
     match table.schema() {
         // TODO: Serialize to JSON instead of printing Rust types.
         Some(schema) => println!("schema: {schema:#?}"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,46 +9,57 @@ struct Cli {
     pub cmd: Command,
 }
 
+impl Cli {
+    /// Get the URI argument passed to a subcommand.
+    fn get_uri(&self) -> &Url {
+        self.cmd.get_uri()
+    }
+}
+
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Optimize a table with Compaction.
-    Compact {
-        #[clap(flatten)]
-        location: TableUri,
-    },
+    Compact(CompactArgs),
     /// Optimize a table with Z-Ordering.
     #[clap(name = "zorder")]
-    ZOrder {
-        #[clap(flatten)]
-        location: TableUri,
-
-        /// Comma-separated list of columns to order on.
-        #[arg(long, short, required = true, num_args = 1.., value_delimiter = ',')]
-        columns: Vec<String>,
-    },
+    ZOrder(ZOrderArgs),
     /// Vacuum table files marked for removal.
-    Vacuum {
-        #[clap(flatten)]
-        location: TableUri,
-        #[clap(flatten)]
-        args: VacuumArgs,
-    },
+    Vacuum(VacuumArgs),
     /// Get the schema of a table.
-    Schema {
-        #[clap(flatten)]
-        location: TableUri,
-    },
+    Schema(SchemaArgs),
 }
 
-#[derive(Debug, Clone, Args)]
-struct TableUri {
-    /// URI pointing to the table location.
-    #[arg(last = true, value_name = "URI", value_parser = verify_uri)]
-    url: Url,
+impl Command {
+    /// Get the required URI argument passed to any of the sub-commands.
+    fn get_uri(&self) -> &Url {
+        match self {
+            Self::Compact(args) => &args.location.url,
+            Self::ZOrder(args) => &args.location.url,
+            Self::Vacuum(args) => &args.location.url,
+            Self::Schema(args) => &args.location.url,
+        }
+    }
+}
+
+#[derive(Debug, Args)]
+struct CompactArgs {
+    #[clap(flatten)]
+    location: TableUri,
+}
+
+#[derive(Debug, Args)]
+struct ZOrderArgs {
+    #[clap(flatten)]
+    location: TableUri,
+    /// Comma-separated list of columns to order on.
+    #[arg(long, short, required = true, num_args = 1.., value_delimiter = ',')]
+    columns: Vec<String>,
 }
 
 #[derive(Debug, Clone, Args)]
 pub struct VacuumArgs {
+    #[clap(flatten)]
+    location: TableUri,
     /// Override the default retention period for which files are deleted.
     #[arg(long)]
     pub retention_days: Option<u32>,
@@ -58,6 +69,19 @@ pub struct VacuumArgs {
     /// Only determine which files can be deleted.
     #[arg(long)]
     pub dry_run: bool,
+}
+
+#[derive(Debug, Args)]
+struct SchemaArgs {
+    #[clap(flatten)]
+    location: TableUri,
+}
+
+#[derive(Debug, Clone, Args)]
+struct TableUri {
+    /// URI pointing to the table location.
+    #[arg(value_name = "URI", value_parser = verify_uri)]
+    url: Url,
 }
 
 fn verify_uri(input: &str) -> Result<Url, DeltaTableError> {
@@ -72,10 +96,13 @@ fn verify_uri(input: &str) -> Result<Url, DeltaTableError> {
 async fn main() {
     let cli = Cli::parse();
 
+    let uri = cli.get_uri();
+    let table = deltalake::open_table(uri).await.unwrap();
+
     let result = match cli.cmd {
-        Command::Compact { location } => delta::compact(location.url).await,
-        Command::ZOrder { location, columns } => delta::zorder(location.url, columns).await,
-        Command::Vacuum { location, args } => {
+        Command::Compact(_) => delta::compact(table).await,
+        Command::ZOrder(args) => delta::zorder(table, args.columns).await,
+        Command::Vacuum(args) => {
             let retention_period = args
                 .retention_days
                 .map(|days| chrono::Duration::days(days.into()));
@@ -84,9 +111,9 @@ async fn main() {
                 retention_period,
                 dry_run: args.dry_run,
             };
-            delta::vacuum(location.url, options).await
+            delta::vacuum(table, options).await
         }
-        Command::Schema { location } => delta::schema(location.url).await,
+        Command::Schema(_) => delta::schema(&table).await,
     };
 
     if let Err(err) = result {


### PR DESCRIPTION
### Description

A clap CLI with subcommands can't have a global required argument. The argument must either be optional (which the URI isn't) or be passed as argument to each subcommand. Previous implementation matched each sub-command's explicit arguments. The new implementation abstracts each sub-command's arguments to its own struct.

The `Command` enum also implement a `get_uri` to read the (required) URI argument passed to any of the sub-commands directly from the top-level `Cli` struct.