### PR TITLE
Add CLI options for optimize operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+
+[[package]]
 name = "arrow"
 version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,9 +684,11 @@ dependencies = [
 name = "deltactl"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap",
  "deltalake",
+ "humantime",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,12 @@ edition = "2021"
 chrono = "0.4.38"
 clap = { version = "4.5.20", features = ["derive"] }
 deltalake = "0.20.1"
+humantime = "2.1.0"
 serde = "1.0.217"
 serde_json = "1.0.137"
 tokio = "1.40.0"
 url = "2.5.2"
+anyhow = "1.0.95"
 
 [profile.release]
 strip = true

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -1,4 +1,3 @@
-use chrono::Duration;
 use deltalake::{
     operations::optimize::{OptimizeBuilder, OptimizeType},
     DeltaOps, DeltaTable, DeltaTableError,
@@ -76,7 +75,7 @@ pub async fn zorder(
 
 pub struct VacuumOptions {
     pub enforce_retention: bool,
-    pub retention_period: Option<Duration>,
+    pub retention_period: Option<chrono::Duration>,
     pub dry_run: bool,
     pub print_files: bool,
 }
@@ -89,8 +88,8 @@ pub async fn vacuum(table: DeltaTable, options: VacuumOptions) -> Result<(), Del
         .vacuum()
         .with_enforce_retention_duration(options.enforce_retention)
         .with_dry_run(options.dry_run);
-    if let Some(days) = options.retention_period {
-        builder = builder.with_retention_period(days);
+    if let Some(retention_period) = options.retention_period {
+        builder = builder.with_retention_period(retention_period);
     }
 
     let (table, metrics) = builder.await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,7 @@ pub struct VacuumArgs {
     /// Only determine which files can be deleted.
     #[arg(long)]
     pub dry_run: bool,
+    /// Whether to print deleted files.
     #[arg(long)]
     pub print_files: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all, clippy::pedantic, clippy::nursery)]
+
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand};
 use deltactl::delta;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ struct Cli {
 
 impl Cli {
     /// Get the URI argument passed to a subcommand.
-    fn get_uri(&self) -> &Url {
+    const fn get_uri(&self) -> &Url {
         self.cmd.get_uri()
     }
 }
@@ -34,7 +34,7 @@ enum Command {
 
 impl Command {
     /// Get the required URI argument passed to any of the sub-commands.
-    fn get_uri(&self) -> &Url {
+    const fn get_uri(&self) -> &Url {
         match self {
             Self::Compact(args) => &args.location.url,
             Self::ZOrder(args) => &args.location.url,


### PR DESCRIPTION
### Description

* Add options for `compact` and `vacuum` commands
* Parse human-readable duration from command-line
* Document the `print-files` option  for `vacuum`
* Add warns for clippy pedantic and nursery lints