### PR TITLE
Enable specifying partition filters for `optimize` ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,6 +1093,7 @@ dependencies = [
  "clap",
  "deltalake",
  "humantime",
+ "nom",
  "serde",
  "serde_json",
  "tokio",
@@ -1956,6 +1957,15 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = "1.0.137"
 tokio = "1.40.0"
 url = "2.5.2"
 anyhow = "1.0.95"
+nom = "8.0.0"
 
 [features]
 azure = [ "deltalake/azure" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod delta;
+pub mod parse;

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,8 +72,8 @@ struct CompactArgs {
 struct ZOrderArgs {
     #[clap(flatten)]
     location: TableUri,
-    /// Comma-separated list of columns to order on.
-    #[arg(long, short, required = true, num_args = 1.., value_delimiter = ',')]
+    /// Columns to order on; repeat option for each column.
+    #[arg(long, short, required = true, number_of_values = 1)]
     columns: Vec<String>,
     #[clap(flatten)]
     options: OptimizeArgs,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,122 @@
+use nom::branch::alt;
+use nom::bytes::complete::{tag, tag_no_case};
+use nom::character::{
+    char,
+    complete::{alpha1, alphanumeric1, one_of, space0},
+};
+use nom::combinator::recognize;
+use nom::multi::{many0_count, many1_count};
+use nom::number::complete::recognize_float;
+use nom::sequence::{delimited, pair, preceded, terminated};
+use nom::{IResult, Parser};
+
+fn filter_operator(input: &str) -> IResult<&str, &str> {
+    terminated(
+        preceded(
+            space0,
+            alt((
+                tag("="),
+                tag("!="),
+                tag(">="),
+                tag(">"),
+                tag("<="),
+                tag("<"),
+                tag_no_case("in"),
+                tag_no_case("not in"),
+            )),
+        ),
+        space0,
+    )
+    .parse(input)
+}
+
+fn column_name(input: &str) -> IResult<&str, &str> {
+    recognize(pair(
+        alt((alpha1, tag("_"))),
+        many0_count(alt((alphanumeric1, tag("_")))),
+    ))
+    .parse(input)
+}
+
+fn filter_field(input: &str) -> IResult<&str, &str> {
+    alt(
+        (
+            recognize_float,                              // e.g. 42.42
+            recognize(many1_count(one_of("0123456789"))), // e.g. 123
+            delimited(
+                char('\''), // must discard valid; i.e. "'2021-01-01'" -> "2021-01-01"
+                recognize(many1_count(alt((
+                    alphanumeric1,
+                    tag("_"),
+                    tag("-"),
+                    tag("."),
+                )))),
+                char('\''),
+            ),
+        ), // e.g. 'some_string'
+           // todo: IN (), NOT IN ()
+    )
+    .parse(input)
+}
+
+pub fn filter_condition(input: &str) -> Result<(&str, &str, &str), anyhow::Error> {
+    let res = (
+        preceded(space0, column_name),
+        preceded(space0, filter_operator),
+        preceded(space0, filter_field),
+    )
+        .parse(input);
+
+    match res {
+        Ok((_, value)) => Ok(value),
+        Err(_) => Err(anyhow::anyhow!("invalid partition filter: {input}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_column_name() {
+        let (_, got) = column_name("my_column").unwrap();
+        assert_eq!(got, "my_column");
+    }
+
+    #[test]
+    fn test_operator_isolated() {
+        let operators = ["=", "!=", ">=", ">", "<=", "<", "in", "not in"];
+        for op in operators {
+            let (_, got) = filter_operator(op).unwrap();
+            assert_eq!(got, op);
+        }
+    }
+
+    #[test]
+    fn test_operator_spaced() {
+        let ops_isolated = ["=", "!=", ">=", ">", "<=", "<", "in", "not in"];
+        let ops_input = [" =", "!=  ", " >= ", " >", "<=  ", "<", " in ", " not in "];
+        for (i, op) in ops_input.into_iter().enumerate() {
+            let (_, got) = filter_operator(op).unwrap();
+            assert_eq!(got, ops_isolated[i]);
+        }
+    }
+
+    #[test]
+    fn test_filter_field_isolated() {
+        let fields = ["1.42", "123", "'some_string'", "'2024-02-21'"];
+        for field in fields {
+            let (_, got) = filter_field(field).unwrap();
+            assert_eq!(got, field);
+        }
+    }
+
+    #[test]
+    fn test_filter_condition() {
+        let inputs = ["id > 200"];
+        let expected = [("id", ">", "200")];
+        for (i, input) in inputs.into_iter().enumerate() {
+            let got = filter_condition(input).unwrap();
+            assert_eq!(got, expected[i]);
+        }
+    }
+}


### PR DESCRIPTION
### Description

Add CLI option for specifying partition filters for `compact` and `zorder` commands. These filters are optional predicates on partition columns, and allows [optimization](https://docs.delta.io/latest/optimizations-oss.html#language-sql) jobs to be executed on a subset of a potentially large dataset.

For instance (SQL representation):

```sql
OPTIMIZE large_table WHERE date >= '2017-01-01';
--                         ^^^^^^^^^^^^^^^^^^^^
--                         filter/predicate
```

### Todo

- Support `IN` and `NOT IN` predicates
- Test command-line option parsing for robustness
