### PR TITLE
Simplify CLI implementation for URI argument

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 chrono = "0.4.38"
-clap = { version = "4.5.20", features = ["derive"] }
+clap = { version = "4.5.20", features = ["derive", "env"] }
 deltalake = { version = "0.28.1" }
 humantime = "2.1.0"
 serde = "1.0.217"

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -1,10 +1,8 @@
 use chrono::DateTime;
 use deltalake::kernel::{Metadata, Protocol};
-use deltalake::{
-    DeltaOps, DeltaTable, DeltaTableError,
-};
 #[cfg(feature = "optimize")]
 use deltalake::operations::optimize::{OptimizeBuilder, OptimizeType};
+use deltalake::{DeltaOps, DeltaTable, DeltaTableError};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::io::Write;

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,12 +31,12 @@ enum Command {
     Vacuum(VacuumArgs),
     /// Set table properties.
     Configure(ConfigureArgs),
-    /// Create a new checkpoint at current table version.
+    /// Create a new checkpoint at the current table version.
     Checkpoint,
-    /// Delete expired log files before current table version.
+    /// Delete expired log files before the current table version.
     ///
-    /// The table log retention is based on the `logRetentionDuration`
-    /// property of the table, 30 days by default.
+    /// The table log retention policy is based on the
+    /// `logRetentionDuration` property of the table, 30 days by default.
     Expire,
     /// Print the schema of a table.
     Schema,
@@ -86,7 +86,7 @@ struct OptimizeArgs {
     /// Whether to preserve insertion order within files.
     #[arg(long)]
     preserve_insertion_order: bool,
-    /// Min commit interval; e.g. 2min
+    /// Min commit interval; e.g. '2min'.
     ///
     /// Commit transaction incrementally, instead of a single commit.
     #[arg(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,13 @@ struct Cli {
     /// URI pointing to the table location.
     #[arg(long, short, global = true, value_parser = verify_uri, env = "DELTA_TABLE_URI")]
     uri: Option<Url>,
+    /// Explicit storage options for the cloud storage provider.
+    ///
+    /// Repeat the option for each pair: -o a=1 -o b=2
+    ///
+    /// The specific storage provider is derived from the table `uri`. The available options
+    /// are documented for each supported provider in the `object_store` crate, and can
+    /// be loaded from environment variables.
     #[arg(long, short = 'o', number_of_values = 1, value_parser = parse_key_val)]
     pub storage_options: Option<Vec<(String, String)>>,
 }


### PR DESCRIPTION
### Description

It's not possible to have global required options in `clap`. The alternatives are:

1. Identical required argument on each sub-command (as currently);
2. A global non-required option (as in this change).

The URI is really required to do anything meaningful in the program, but the implementation to achieve alt. 1 is overy complex. A simpler solution is alt. 2, with an explicit early exit when the URI is not provided. This also makes sense since a production use of the CLI might prefer to point to the table using an env var, which has to treat the URI an _option_ on the command line since it can be configured in multiple ways.

#### Changes:
* Move table URI cli arg to global option (alt as env var)
* Fix grammar in cli doc
* Add cli doc for `storage_options`