### PR TITLE
Improve build time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,15 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-chrono = "0.4.38"
+chrono = { version = "0.4.38", default-features = false }
 clap = { version = "4.5.20", features = ["derive", "env"] }
-deltalake = { version = "0.28.1" }
+deltalake = "0.28.1"
 humantime = "2.1.0"
-serde = "1.0.217"
+serde = { version = "1.0.217", default-features = false }
 serde_json = "1.0.137"
-tokio = "1.40.0"
-url = "2.5.2"
-anyhow = "1.0.95"
+tokio = { version = "1.40.0", default-features = false, features = ["rt-multi-thread", "macros"] }
+url = { version = "2.5.2", default-features = false }
+anyhow = { version = "1.0.95", default-features = false }
 
 [features]
 azure = ["deltalake/azure"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,27 @@
-FROM rust:latest AS builder
-
-RUN rustup target add x86_64-unknown-linux-musl
-RUN apt -y update
-RUN apt install -y musl-tools musl-dev
-RUN apt-get install -y build-essential
-RUN apt install -y gcc-x86-64-linux-gnu
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
 WORKDIR /app
-COPY src src
+
+# Step 1: Compute a recipe file
+FROM chef as planner
+WORKDIR /app
+COPY src ./src
 COPY Cargo.* .
+RUN cargo chef prepare --recipe-path recipe.json
 
-RUN cargo build --target x86_64-unknown-linux-musl --release
-
-FROM scratch
+# Step 2.1: Cache project dependencies
+FROM chef as builder
 WORKDIR /app
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/deltactl ./
-ENTRYPOINT ["./deltactl"]
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Step 2.2: Build the binary
+# NOTE: Feature flags may need to be enabled.
+COPY src ./src
+COPY Cargo.* .
+RUN cargo build --release --bin deltactl
+
+# Step 4: Copy the binary to a runtime image
+FROM linuxcontainers/debian-slim:12 as runtime
+WORKDIR /app
+COPY --from=builder /app/target/release/deltactl /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/deltactl"]


### PR DESCRIPTION
### Description

* Remove unused default features from dependencies. This has a minimal improvement to build time; from 9.54s to 8.65s.
* Use [cargo-chef](https://github.com/LukeMathWalker/cargo-chef) to cache dependencies in Docker builds. This improves build time when rebuilding the image. Note that the image is no longer build using the musl libraries, so the image is much larger (125 GiB). This can be achieved with [cargo-chef on alpine](https://github.com/LukeMathWalker/cargo-chef#running-the-binary-in-alpine).