### PR TITLE
Add useful clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,33 @@ optimize = ["deltalake/datafusion"]
 strip = true
 lto = true
 codegen-units = 1
+
+[lints.clippy]
+# Pedantic
+pedantic = { level = "warn", priority = -1 }
+cast_precision_loss = "allow"
+default_trait_access = "allow"
+missing_errors_doc = "allow"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+struct_excessive_bools = "allow"
+map_unwrap_or = "allow"
+unnecessary_debug_formatting = "allow"
+implicit_hasher = "allow"
+
+# Nursery
+nursery = { level = "warn", priority = -1 }
+option_if_let_else = "allow"
+
+# Cargo
+wildcard_dependencies = "warn"
+
+# Restriction
+allow_attributes = "warn"
+clone_on_ref_ptr = "warn"
+create_dir = "warn"
+dbg_macro = "warn"
+exit = "warn"
+string_to_string = "warn"
+undocumented_unsafe_blocks = "warn"
+unwrap_used = "warn"

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -155,16 +155,19 @@ pub fn check_compatibility(table: DeltaTable) -> Result<(), DeltaTableError> {
         eprintln!("table has no state");
         return Ok(());
     };
-    let mut can_rw: bool = true;
-    if let Err(e) = deltalake::kernel::transaction::PROTOCOL.can_read_from(&state) {
+    let can_read = if let Err(e) = deltalake::kernel::transaction::PROTOCOL.can_read_from(&state) {
         eprintln!("{e}");
-        can_rw = false;
-    }
-    if let Err(e) = deltalake::kernel::transaction::PROTOCOL.can_write_to(&state) {
+        false
+    } else {
+        true
+    };
+    let can_write = if let Err(e) = deltalake::kernel::transaction::PROTOCOL.can_write_to(&state) {
         eprintln!("{e}");
-        can_rw = false;
-    }
-    if can_rw {
+        false
+    } else {
+        true
+    };
+    if can_read && can_write {
         println!("Table is read and write compatible");
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ pub struct ConfigureArgs {
     ///
     /// Repeat the option for each pair: -p a=1 -p b=2
     ///
-    #[allow(clippy::doc_markdown)]
+    #[expect(clippy::doc_markdown)]
     /// See properties at https://docs.delta.io/latest/table-properties.html
     #[clap(short, number_of_values = 1, value_parser = parse_key_val)]
     properties: Vec<(String, String)>,


### PR DESCRIPTION
### Description

Emit warnings from `pedantic`, `nursery`, `cargo`, and `restriction` groups, with selective allows.